### PR TITLE
sitemap.xml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,3 +10,7 @@ github_username:  OSMBrasil
 # Build settings
 markdown: kramdown
 permalink: pretty
+
+# Plugin settings
+gems:
+  - jekyll-sitemap


### PR DESCRIPTION
Adiciona http://www.openstreetmap.com.br/sitemap.xml

- [x] Ver em produção se os links são para o domínio [openstreetmap.com.br] ‒ **[vide comentário](#issuecomment-122158789)**

Requisito para testar localmente:
```
gem update github-pages
```

---

Foram seguidas [instruções] dadas pelo GitHub. O [projeto do plugin] é "oficial" do serviço.

[openstreetmap.com.br]: http://www.openstreetmap.com.br/
[instruções]: https://help.github.com/articles/using-jekyll-plugins-with-github-pages/#configuring-jekyll
[projeto do plugin]: https://github.com/jekyll/jekyll-sitemap