### PR TITLE
Remover link p/ Scrollback da página Comunidade

### DIFF
--- a/comunidade.md
+++ b/comunidade.md
@@ -23,7 +23,7 @@ Temos dois grupos no Telegram:
 
 ## Chat
 
-No chat desta comunidade, você pode tirar dúvidas com outros colaboradores ou simplesmente bater um papo sobre o OpenStretMap. O chat pode ser acessado pelo link [https://scrollback.io/osm-brasil](https://scrollback.io/osm-brasil/all/all-messages). Este mesmo chat também pode ser acessado via IRC no canal [#osm-br@irc.oftc.net](irc://irc.oftc.net/osm-br).
+No chat desta comunidade, você pode tirar dúvidas com outros colaboradores ou simplesmente bater um papo sobre o OpenStretMap. O chat pode ser acessado via IRC no canal [#osm-br@irc.oftc.net](irc://irc.oftc.net/osm-br).
 
 ## Wiki
 


### PR DESCRIPTION
O projeto Scrollback não está mais sendo desenvolvido e o link que estava presente não funcionava mais.

Do site:
" Scrollback is no longer maintained. If you’d like to maintain it, please email aravindet@gmail.com. "